### PR TITLE
Initialize the whole buffer

### DIFF
--- a/src/tools/dksbuild/dksbuild.cc
+++ b/src/tools/dksbuild/dksbuild.cc
@@ -130,6 +130,7 @@ int main(int argc,char **argv)
     exit(1);
   }
  
+  memset(tekstia+16, 0, sizeof(tekstia)-16);
   strcpy(tekstia,"DKS Datafile\n\032\n"); 
 
   printf("\nReading file %s\n",argv[1]);


### PR DESCRIPTION
Without this patch, the `fokker.dks` file produced by `dksbuild`
varied in byte 17 depending on the type of emulated VM CPU.

This patch was done while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).